### PR TITLE
Disscard tsumo tile automatically after riichi is accepted

### DIFF
--- a/python/mjai/bot/base.py
+++ b/python/mjai/bot/base.py
@@ -513,6 +513,15 @@ class Bot:
                     json.dumps(event)
                 )
 
+            # NOTE: Skip `think()` if the player's riichi is accepted and
+            # no call actions are allowed.
+            if (
+                self.self_riichi_accepted
+                and not (self.can_agari or self.can_kakan or self.can_ankan)
+                and self.can_discard
+            ):
+                return self.action_discard(self.last_self_tsumo)
+
             resp = self.think()
             return resp
 


### PR DESCRIPTION
In high-level API, `aciton_discard()` must be called even after riichi is accepted. To reduce the risk of errors, tsumo should be automatically discarded when kan or hora cannot be selected.