### PR TITLE
Rename function names on mjai.bot.tools

### DIFF
--- a/python/mjai/bot/base.py
+++ b/python/mjai/bot/base.py
@@ -3,9 +3,9 @@ import sys
 
 from mjai.bot.consts import MJAI_VEC34_TILES
 from mjai.bot.tools import (
-    _fmt_short_call,
-    convert_mjai_tiles_to_vec34,
-    convert_tehai_vec34_as_short,
+    convert_mjai_to_vec34,
+    convert_vec34_to_short,
+    fmt_call,
     fmt_calls,
     vec34_index_to_mjai_tile,
 )
@@ -255,7 +255,7 @@ class Bot:
             >>> bot.tehai
             "123m134p4567s6z(p5z3)"
         """
-        tehai_str = convert_tehai_vec34_as_short(
+        tehai_str = convert_vec34_to_short(
             self.player_state.tehai, self.player_state.akas_in_hand
         )
         events = self.get_call_events(self.player_id)
@@ -645,7 +645,7 @@ class Bot:
         new_tehai_mjai = self.tehai_mjai.copy()
         new_tehai_mjai.remove(consumed[0])
         new_tehai_mjai.remove(consumed[1])
-        new_call_str = _fmt_short_call(
+        new_call_str = fmt_call(
             {
                 "type": "pon",
                 "consumed": consumed,
@@ -656,8 +656,8 @@ class Bot:
             self.player_id,
         )
 
-        tehai_str = convert_tehai_vec34_as_short(
-            convert_mjai_tiles_to_vec34(new_tehai_mjai),
+        tehai_str = convert_vec34_to_short(
+            convert_mjai_to_vec34(new_tehai_mjai),
             self.player_state.akas_in_hand,
         )
         events = self.get_call_events(self.player_id)
@@ -851,7 +851,7 @@ class Bot:
         new_tehai_mjai = self.tehai_mjai.copy()
         new_tehai_mjai.remove(consumed[0])
         new_tehai_mjai.remove(consumed[1])
-        new_call_str = _fmt_short_call(
+        new_call_str = fmt_call(
             {
                 "type": "chi",
                 "consumed": consumed,
@@ -861,8 +861,8 @@ class Bot:
             },
             self.player_id,
         )
-        tehai_str = convert_tehai_vec34_as_short(
-            convert_mjai_tiles_to_vec34(new_tehai_mjai),
+        tehai_str = convert_vec34_to_short(
+            convert_mjai_to_vec34(new_tehai_mjai),
             self.player_state.akas_in_hand,
         )
         events = self.get_call_events(self.player_id)

--- a/python/mjai/bot/base.py
+++ b/python/mjai/bot/base.py
@@ -3,15 +3,15 @@ import sys
 
 from mjai.bot.consts import MJAI_VEC34_TILES
 from mjai.bot.tools import (
+    calc_shanten,
     convert_mjai_to_vec34,
     convert_vec34_to_short,
+    find_improving_tiles,
     fmt_call,
     fmt_calls,
     vec34_index_to_mjai_tile,
 )
 from mjai.mlibriichi.state import ActionCandidate, PlayerState  # type: ignore
-from mjai.mlibriichi.tools import calc_shanten  # type: ignore
-from mjai.mlibriichi.tools import find_improving_tiles  # type: ignore
 
 
 class Bot:

--- a/python/mjai/bot/tools.py
+++ b/python/mjai/bot/tools.py
@@ -1,24 +1,36 @@
 """
-
-* tile id = [0, ..., 33]
+Tile Conversion:
+- convert_mjai_to_vec34(mjai_tiles: list[str]) -> list[int]
+- convert_vec34_to_short(tehai_vec34: list[int], akas_in_hand: list[bool] | None) -> str  # noqa
+- vec34_index_to_short_tile(index: int) -> str
+- vec34_index_to_mjai_tile(index: int) -> str
 
 """
 from mjai.bot.consts import MJAI_VEC34_TILES
+from mjai.mlibriichi.tools import calc_shanten  # noqa, type: ignore
 from mjai.mlibriichi.tools import find_improving_tiles  # noqa, type: ignore
 
 
-def convert_mjai_tiles_to_vec34(
-    tiles: list[str],
+def convert_mjai_to_vec34(
+    mjai_tiles: list[str],
 ) -> list[int]:
+    """
+    Convert mjai tiles to vec34 format
+
+    Example:
+        >>> convert_mjai_tiles_to_vec34(["1m", "2m", "3m", "5mr", "5m", "1p"])
+        [1, 1, 1, 0, 2, 0, 0, 0, 0, 1, ...]
+
+    """
     vec34_tiles = [0] * 34
-    for mjai_tile in tiles:
+    for mjai_tile in mjai_tiles:
         mjai_tile = mjai_tile.replace("r", "")
         idx = MJAI_VEC34_TILES.index(mjai_tile)
         vec34_tiles[idx] += 1
     return vec34_tiles
 
 
-def convert_tehai_vec34_as_short(
+def convert_vec34_to_short(
     tehai_vec34: list[int], akas_in_hand: list[bool] | None = None
 ) -> str:
     """
@@ -71,139 +83,6 @@ def convert_tehai_vec34_as_short(
         shortline_elems.append("".join(map(str, zis)) + "z")
 
     return "".join(shortline_elems)
-
-
-def fmt_calls(events: list[dict], player_id: int) -> str:
-    calls = []
-    kakan_calls = []
-
-    for ev in events:
-        call = _fmt_short_call(ev, player_id)
-        if ev["type"] == "kakan":
-            kakan_calls.append(call)
-        elif ev["type"] in ["chi", "pon", "daiminkan", "ankan"]:
-            calls.append(call)
-
-    for kakan_call in kakan_calls:
-        tile = kakan_call[2:4]
-        for i, call in enumerate(calls):
-            if call[2:4] == tile and call[1] == "p":
-                rel_pose = call[4]
-                kakan_call[4] = rel_pose
-                calls[i] = kakan_call
-                break
-
-    return "".join(calls)
-
-
-def _fmt_short_call(ev: dict, player_id: int) -> str:
-    if ev["type"] == "pon":
-        rel_pos = (ev["target"] - player_id + 4) % 4
-        call_tiles = [
-            mjai_tile_to_short(ev["pai"]),
-            mjai_tile_to_short(ev["consumed"][0]),
-            mjai_tile_to_short(ev["consumed"][1]),
-        ]
-        return "(p{}{}{})".format(
-            deaka_short_tile(call_tiles[0]),
-            rel_pos,
-            "r"
-            if any([is_aka_short_tile(tile) for tile in call_tiles])
-            else "",
-        )
-    elif ev["type"] == "chi":
-        color = ev["pai"][1]
-        consecutive_nums = "".join(
-            list(
-                sorted(
-                    [
-                        mjai_tile_to_short(ev["pai"])[0],
-                        mjai_tile_to_short(ev["consumed"][0])[0],
-                        mjai_tile_to_short(ev["consumed"][1])[0],
-                    ]
-                )
-            )
-        )
-        called_tile_idx = 0
-        if consecutive_nums[0] == mjai_tile_to_short(ev["pai"])[0]:
-            called_tile_idx = 0
-        elif consecutive_nums[1] == mjai_tile_to_short(ev["pai"])[0]:
-            called_tile_idx = 1
-        else:
-            called_tile_idx = 2
-        return f"({consecutive_nums}{color}{called_tile_idx})"
-    elif ev["type"] in ["daiminkan"]:
-        rel_pos = (ev["target"] - player_id + 4) % 4
-        call_tiles = [
-            mjai_tile_to_short(ev["pai"]),
-            mjai_tile_to_short(ev["consumed"][0]),
-            mjai_tile_to_short(ev["consumed"][1]),
-            mjai_tile_to_short(ev["consumed"][2]),
-        ]
-        return "(k{}{}{})".format(
-            deaka_short_tile(call_tiles[0]),
-            rel_pos,
-            "r"
-            if any([is_aka_short_tile(tile) for tile in call_tiles])
-            else "",
-        )
-    elif ev["type"] in ["ankan"]:
-        rel_pos = (ev["target"] - player_id + 4) % 4
-        call_tiles = [
-            mjai_tile_to_short(ev["consumed"][0]),
-            mjai_tile_to_short(ev["consumed"][1]),
-            mjai_tile_to_short(ev["consumed"][2]),
-            mjai_tile_to_short(ev["consumed"][3]),
-        ]
-        return "(k{}{}{})".format(
-            deaka_short_tile(call_tiles[0]),
-            rel_pos,
-            "r"
-            if any([is_aka_short_tile(tile) for tile in call_tiles])
-            else "",
-        )
-    elif ev["type"] == "kakan":
-        rel_pos = 0  # NOTE: `rel_pose` will be replaced in `fmt_calls`
-
-        call_tiles = [
-            mjai_tile_to_short(ev["pai"]),
-            mjai_tile_to_short(ev["consumed"][0]),
-            mjai_tile_to_short(ev["consumed"][1]),
-            mjai_tile_to_short(ev["consumed"][2]),
-        ]
-        return "(s{}{}{})".format(
-            deaka_short_tile(call_tiles[0]),
-            rel_pos,
-            "r"
-            if any([is_aka_short_tile(tile) for tile in call_tiles])
-            else "",
-        )
-    else:
-        return ""
-
-
-def is_aka_short_tile(tile: str) -> bool:
-    return tile in ["0m", "0p", "0s"]
-
-
-def deaka_short_tile(tile: str) -> str:
-    return f"5{tile[1]}" if is_aka_short_tile(tile) else tile
-
-
-def mjai_tile_to_short(tile: str) -> str:
-    mapping = {
-        "5mr": "0m",
-        "5pr": "0s",
-        "5sr": "0p",
-        "E": "1z",
-        "S": "2z",
-        "W": "3z",
-        "N": "4z",
-        "P": "5z",
-        "F": "6z",
-        "C": "7z",
-    }
-    return mapping.get(tile, tile)
 
 
 def vec34_index_to_short_tile(index: int) -> str:
@@ -308,3 +187,146 @@ def vec34_index_to_mjai_tile(index: int) -> str:
         "C",
     ]
     return tiles[index]
+
+
+def fmt_calls(events: list[dict], player_id: int) -> str:
+    calls = []
+    kakan_calls = []
+
+    for ev in events:
+        call = fmt_call(ev, player_id)
+        if ev["type"] == "kakan":
+            kakan_calls.append(call)
+        elif ev["type"] in ["chi", "pon", "daiminkan", "ankan"]:
+            calls.append(call)
+
+    for kakan_call in kakan_calls:
+        tile = kakan_call[2:4]
+        for i, call in enumerate(calls):
+            if call[2:4] == tile and call[1] == "p":
+                rel_pose = call[4]
+                kakan_call[4] = rel_pose
+                calls[i] = kakan_call
+                break
+
+    return "".join(calls)
+
+
+def fmt_call(ev: dict, player_id: int) -> str:
+    if ev["type"] == "pon":
+        rel_pos = (ev["target"] - player_id + 4) % 4
+        call_tiles = [
+            __mjai_tile_to_short(ev["pai"]),
+            __mjai_tile_to_short(ev["consumed"][0]),
+            __mjai_tile_to_short(ev["consumed"][1]),
+        ]
+        return "(p{}{}{})".format(
+            __deaka_short_tile(call_tiles[0]),
+            rel_pos,
+            "r"
+            if any([__is_aka_short_tile(tile) for tile in call_tiles])
+            else "",
+        )
+    elif ev["type"] == "chi":
+        color = ev["pai"][1]
+        consecutive_nums = "".join(
+            list(
+                sorted(
+                    [
+                        __mjai_tile_to_short(ev["pai"])[0],
+                        __mjai_tile_to_short(ev["consumed"][0])[0],
+                        __mjai_tile_to_short(ev["consumed"][1])[0],
+                    ]
+                )
+            )
+        )
+        called_tile_idx = 0
+        if consecutive_nums[0] == __mjai_tile_to_short(ev["pai"])[0]:
+            called_tile_idx = 0
+        elif consecutive_nums[1] == __mjai_tile_to_short(ev["pai"])[0]:
+            called_tile_idx = 1
+        else:
+            called_tile_idx = 2
+        return f"({consecutive_nums}{color}{called_tile_idx})"
+    elif ev["type"] in ["daiminkan"]:
+        rel_pos = (ev["target"] - player_id + 4) % 4
+        call_tiles = [
+            __mjai_tile_to_short(ev["pai"]),
+            __mjai_tile_to_short(ev["consumed"][0]),
+            __mjai_tile_to_short(ev["consumed"][1]),
+            __mjai_tile_to_short(ev["consumed"][2]),
+        ]
+        return "(k{}{}{})".format(
+            __deaka_short_tile(call_tiles[0]),
+            rel_pos,
+            "r"
+            if any([__is_aka_short_tile(tile) for tile in call_tiles])
+            else "",
+        )
+    elif ev["type"] in ["ankan"]:
+        rel_pos = (ev["target"] - player_id + 4) % 4
+        call_tiles = [
+            __mjai_tile_to_short(ev["consumed"][0]),
+            __mjai_tile_to_short(ev["consumed"][1]),
+            __mjai_tile_to_short(ev["consumed"][2]),
+            __mjai_tile_to_short(ev["consumed"][3]),
+        ]
+        return "(k{}{}{})".format(
+            __deaka_short_tile(call_tiles[0]),
+            rel_pos,
+            "r"
+            if any([__is_aka_short_tile(tile) for tile in call_tiles])
+            else "",
+        )
+    elif ev["type"] == "kakan":
+        rel_pos = 0  # NOTE: `rel_pose` will be replaced in `fmt_calls`
+
+        call_tiles = [
+            __mjai_tile_to_short(ev["pai"]),
+            __mjai_tile_to_short(ev["consumed"][0]),
+            __mjai_tile_to_short(ev["consumed"][1]),
+            __mjai_tile_to_short(ev["consumed"][2]),
+        ]
+        return "(s{}{}{})".format(
+            __deaka_short_tile(call_tiles[0]),
+            rel_pos,
+            "r"
+            if any([__is_aka_short_tile(tile) for tile in call_tiles])
+            else "",
+        )
+    else:
+        return ""
+
+
+def __is_aka_short_tile(tile: str) -> bool:
+    return tile in ["0m", "0p", "0s"]
+
+
+def __deaka_short_tile(tile: str) -> str:
+    """
+    Convert akadora to 5{m,p,s} tile
+
+    Example:
+        >>> __deaka_short_tile("0m")
+        "5m"
+
+        >>> __deaka_short_tile("1z")
+        "1z"
+    """
+    return f"5{tile[1]}" if __is_aka_short_tile(tile) else tile
+
+
+def __mjai_tile_to_short(tile: str) -> str:
+    mapping = {
+        "5mr": "0m",
+        "5pr": "0s",
+        "5sr": "0p",
+        "E": "1z",
+        "S": "2z",
+        "W": "3z",
+        "N": "4z",
+        "P": "5z",
+        "F": "6z",
+        "C": "7z",
+    }
+    return mapping.get(tile, tile)

--- a/tests/mjai/bot/test_tools.py
+++ b/tests/mjai/bot/test_tools.py
@@ -1,6 +1,6 @@
 import pytest
 from mjai.bot.tools import (
-    convert_tehai_vec34_as_short,
+    convert_vec34_to_short,
     find_improving_tiles,
     vec34_index_to_mjai_tile,
     vec34_index_to_short_tile,
@@ -56,13 +56,10 @@ def test_convert_tehai_vec34_as_short(
     tehai_vec34_ryanpeikou_chanta, tehai_vec34_random
 ):
     assert (
-        convert_tehai_vec34_as_short(tehai_vec34_ryanpeikou_chanta)
+        convert_vec34_to_short(tehai_vec34_ryanpeikou_chanta)
         == "112233m112233p77z"
     )
-    assert (
-        convert_tehai_vec34_as_short(tehai_vec34_random)
-        == "113479m4p33556s47z"
-    )
+    assert convert_vec34_to_short(tehai_vec34_random) == "113479m4p33556s47z"
 
 
 def test_vec34_index_to_mjai_tile():


### PR DESCRIPTION
Rename function names on `mjai.bot.tools`.

* `_fmt_short_call` -> `fmt_call`
* `convert_mjai_tiles_to_vec34` -> `convert_mjai_to_vec34`
* `convert_tehai_vec34_as_short` -> `convert_vec34_to_short`