### PR TITLE
Bugfix: kakan needs `pai` argument

### DIFF
--- a/python/mjai/bot/base.py
+++ b/python/mjai/bot/base.py
@@ -498,18 +498,29 @@ class Bot:
             separators=(",", ":"),
         )
 
-    def action_kakan(self) -> str:
-        consumed = [self.last_self_tsumo.replace("r", "")] * 3
-        if self.last_self_tsumo[
-            0
-        ] == "5" and not self.last_self_tsumo.endswith("r"):
+    def action_kakan(self, pai: str) -> str:
+        """
+        Return a kakan event as a JSON string.
+
+        Args:
+            pai: Tile for kakan. Mjai-style tile string (like 'N' or '5mr')
+
+        Example:
+            >>> bot.action_kakan("5m")
+            '{"type":"kakan","actor":0,"pai":"5m","consumed":["5mr","5m","5m"]}'
+
+            >>> bot.action_kakan("5sr")
+            '{"type":"kakan","actor":0,"pai":"5sr","consumed":["5s","5s","5s"]}'
+        """
+        consumed = [pai.replace("r", "")] * 3
+        if pai[0] == "5" and not pai.endswith("r"):
             consumed[0] = consumed[0] + "r"
 
         return json.dumps(
             {
                 "type": "kakan",
                 "actor": self.player_id,
-                "pai": self.last_self_tsumo,
+                "pai": pai,
                 "consumed": consumed,  # 3 tiles to be consumed
             },
             separators=(",", ":"),

--- a/tests/mjai/bot/test_base.py
+++ b/tests/mjai/bot/test_base.py
@@ -17,7 +17,7 @@ def test_action_kakan_mocktest():
     bot.player_state.akas_in_hand = [False, False, False]
     bot.player_state.last_self_tsumo.return_value = "7m"
     assert bot.tehai == "777789m7789p1s"
-    kakan_json = bot.action_kakan()
+    kakan_json = bot.action_kakan("7m")
     assert json.loads(kakan_json)["type"] == "kakan"
     assert json.loads(kakan_json)["actor"] == 0
     assert json.loads(kakan_json)["pai"] == "7m"
@@ -31,7 +31,7 @@ def test_action_kakan_mocktest():
     bot.player_state.akas_in_hand = [True, False, False]
     bot.player_state.last_self_tsumo.return_value = "5mr"
     assert bot.tehai == "055589m7789p1s"
-    kakan_json = bot.action_kakan()
+    kakan_json = bot.action_kakan("5mr")
     assert json.loads(kakan_json)["type"] == "kakan"
     assert json.loads(kakan_json)["actor"] == 0
     assert json.loads(kakan_json)["pai"] == "5mr"
@@ -45,7 +45,7 @@ def test_action_kakan_mocktest():
     bot.player_state.akas_in_hand = [True, False, False]
     bot.player_state.last_self_tsumo.return_value = "5m"
     assert bot.tehai == "055589m7789p1s"
-    kakan_json = bot.action_kakan()
+    kakan_json = bot.action_kakan("5m")
     assert json.loads(kakan_json)["type"] == "kakan"
     assert json.loads(kakan_json)["actor"] == 0
     assert json.loads(kakan_json)["pai"] == "5m"
@@ -81,7 +81,7 @@ def test_action_kakan_validation():
     events = json.loads(logs)
     for ev in events:
         bot.player_state.update(json.dumps(ev))
-    kakan_json = bot.action_kakan()
+    kakan_json = bot.action_kakan("5mr")
     assert bot.validate_reaction(kakan_json) is None
     assert json.loads(kakan_json)["type"] == "kakan"
     assert json.loads(kakan_json)["actor"] == 0


### PR DESCRIPTION
Resolves https://github.com/smly/mjai.app/issues/50.

Breaking changes in the API:

* adding `pai: str` argument of `action_kakan()`