### PR TITLE
Changes the timeout for the start_kyoku and healthcheck

### DIFF
--- a/python/mjai/bot/riichibot.py
+++ b/python/mjai/bot/riichibot.py
@@ -1,5 +1,4 @@
-"""Reference implementtation with using high-level API.
-"""
+"""Reference impl with using high-level API."""
 
 from mjai import Bot
 

--- a/python/mjai/bot/rulebase.py
+++ b/python/mjai/bot/rulebase.py
@@ -1,5 +1,4 @@
-"""Reference implementtation with using high-level API.
-"""
+"""Reference impl with using high-level API."""
 
 from loguru import logger
 

--- a/python/mjai/player.py
+++ b/python/mjai/player.py
@@ -134,7 +134,7 @@ class MjaiPlayerClient:
                     break
             except requests.exceptions.ConnectionError:
                 time.sleep(0.1)
-                if time.time() - wait_start_ts > 10.0:
+                if time.time() - wait_start_ts > 20.0:
                     raise ValueError(
                         "Failed to receive response from http server: timeout"
                     )
@@ -180,7 +180,7 @@ class MjaiPlayerClient:
             if json.loads(events)[0]["type"] in ["start_game", "start_kyoku"]:
                 # Workaround: To avoid timeouts
                 # Some bots time out when loading models with start_game.
-                timeout_per_action = 10.0
+                timeout_per_action = 20.0
 
             resp = requests.post(
                 f"http://localhost:{self.port_num}",


### PR DESCRIPTION
Ref: https://github.com/smly/mjai.app/discussions/178#discussioncomment-12284995

* Change the timeout for steps starting with start_kyoku and start_game from 10 to 20
* Change the timeout for the healthcheck immediately after the container starts from 10 to 20
