### PR TITLE
fix: red tile kuikae

### DIFF
--- a/python/mjai/bot/base.py
+++ b/python/mjai/bot/base.py
@@ -426,7 +426,10 @@ class Bot:
         """
         assert self.player_state.forbidden_tiles is not None
         assert len(self.player_state.forbidden_tiles) == len(MJAI_VEC34_TILES)
-        return dict(zip(MJAI_VEC34_TILES, self.player_state.forbidden_tiles))
+        forbidden_tiles = dict(zip(MJAI_VEC34_TILES, self.player_state.forbidden_tiles))
+        for red_tile in ["5mr", "5pr", "5sr"]:
+            forbidden_tiles[red_tile] = forbidden_tiles[red_tile[0:2]]
+        return forbidden_tiles
 
     # ==========================================================
     # actions

--- a/tests/mjai/bot/test_base.py
+++ b/tests/mjai/bot/test_base.py
@@ -363,7 +363,7 @@ def test_tsumogiri_bot():
     assert bot.bakaze == "S"
     assert bot.player_state.at_furiten is False
     assert len(bot.tiles_seen) == 34
-    assert len(bot.forbidden_tiles) == 34
+    assert len(bot.forbidden_tiles) == 37
     assert bot.tiles_seen["F"] == 2
     assert bot.tiles_seen["1p"] == 2
     assert (

--- a/tests/mjai/bot/test_base.py
+++ b/tests/mjai/bot/test_base.py
@@ -118,6 +118,36 @@ def test_discardable():
     )
 
 
+def test_red_discardable():
+    bot = Bot(player_id=0)
+
+    # Case1: kuikae example from https://riichi.wiki/Kuikae
+    bot.player_state = MagicMock()
+    # with 5mr
+    bot.player_state.tehai = list(
+        map(int, list("00001110011100000021110000000000000"))
+    )
+    bot.player_state.akas_in_hand = [True, False, False]
+    bot.player_state.forbidden_tiles = [
+        x == "1" for x in list("0000100000000000000000000000000000")
+    ]
+    # 5mr is forbidden to discard
+    assert bot.tehai == "067m123p11234s"
+    assert set(bot.discardable_tiles) == set(
+        [
+            "6m",
+            "7m",
+            "1p",
+            "2p",
+            "3p",
+            "1s",
+            "2s",
+            "3s",
+            "4s",
+        ]
+    )
+
+
 def test_discardable_tiles_riichi_declaration():
     bot = Bot(player_id=0)
 


### PR DESCRIPTION
In the `discardable_tiles()` function, a bug has been fixed in the part that determines whether the mjai-formatted hand list is included in forbidden_tiles, where if the hand contains red tiles, the function would be unable to make a determination and would terminate with an error.

The condition that causes the error can be reproduced using the added test case:

```py
    @property
    def discardable_tiles(self) -> list[str]:
        """
        List of discardable tiles.
    
        Example:
            >>> bot.discardable_tiles
            ["1m", "2m", "6m", "9m", "1p", "3p", "4p", "3s", "4s", "5s",
             "7s", "9s", "5z", "6z"]
        """
        discardable_tiles = list(
            set(
                [
                    tile
                    for tile in self.tehai_mjai
>                   if not self.forbidden_tiles[tile]
                ]
            )
        )
E       KeyError: '5mr'

python/mjai/bot/base.py:301: KeyError
```

I could have left the forbidden_tiles at 34 types and changed red tiles back to black tiles when determining discardable_tiles, but I chose to modify the forbidden_tiles function to have the advantage of being able to consistently comply with the mjai format. I'll be open to changes if there are design guidelines.

---

`discardable_tiles()` 関数内にある、 mjai 形式の手牌リストが forbidden_tiles に含まれるかを判定する部分において、手牌に赤牌が含まれていた場合に判定できずにエラー終了するバグを修正しました。

エラーが起きる状態は追加したテストケースによって再現が可能です（上記）。

forbidden_tiles を 34 種類のままにして、 discardable_tiles の判定時に赤牌を黒牌に戻して判定することも可能ですが、 mjai 形式に一貫して準拠できる利点を考えて、 forbidden_tiles 関数を修正するように選択しました。設計上の指針等あれば変更します。